### PR TITLE
feat: UserRepository 클래스에 Firestore 데이터베이스 작업 추가

### DIFF
--- a/Here-Hear/Repository/Entity/UserEntity.swift
+++ b/Here-Hear/Repository/Entity/UserEntity.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct UserEntity {
+struct UserEntity: Codable {
     var id: String
     var nickname: String
     var createdAt: Date
@@ -20,5 +20,16 @@ extension UserEntity {
             nickname: nickname,
             createdAt: createdAt
         )
+    }
+    func toDictionary() -> [String: Any] {
+        let dateFomatter = DateFormatter()
+        dateFomatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        let createdAtString = dateFomatter.string(from: createdAt)
+        
+        return [
+            "id": id,
+            "nickname": nickname,
+            "createdAt": createdAtString
+        ]
     }
 }

--- a/Here-Hear/Repository/UserRepository.swift
+++ b/Here-Hear/Repository/UserRepository.swift
@@ -6,11 +6,138 @@
 //
 
 import Foundation
+import Combine
+import FirebaseFirestore
+
+enum UserRepositoryError: Error {
+    case notFound
+    case dataUnavailable
+    case networkError
+}
 
 protocol UserRepositoryInterface {
-    
+    func fetchUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError>
+    func addUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError>
+    func updateUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError>
+    func deleteUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError>
 }
 
 class UserRepository: UserRepositoryInterface {
+    private var database = Firestore.firestore()
+    
+    // MARK: 기존 유저 정보 FireStore에서 가져오기
+    func fetchUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        let subject = PassthroughSubject<UserEntity, UserRepositoryError>()
+        
+        database.collection("User").document(user.id).getDocument { document, _  in
+            if let document = document, document.exists {
+                do {
+                    let user = try document.data(as: UserEntity.self)
+                    subject.send(user)
+                } catch {
+                    subject.send(completion: .failure(.dataUnavailable))
+                }
+            } else {
+                subject.send(completion: .failure(.notFound))
+            }
+        }
+        
+        return subject.eraseToAnyPublisher()
+    }
+    
+    // MARK: 새로운 유저 추가하기
+    func addUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        let subject = PassthroughSubject<UserEntity, UserRepositoryError>()
+        
+        let data = user.toDictionary()
+        
+        var ref: DocumentReference?
+        ref = database.collection("User").addDocument(data: user.toDictionary()) { error in
+            if let error = error {
+                subject.send(completion: .failure(.dataUnavailable))
+            } else {
+                if let ref = ref {
+                    var newUser = user
+                    newUser.id = ref.documentID
+                    subject.send(newUser)
+                    subject.send(completion: .finished)
+                }
+            }
+        }
+        
+        return subject.eraseToAnyPublisher()
+    }
+    // MARK: 기존 유저 정보 변경하기
+    func updateUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        let subject = PassthroughSubject<UserEntity, UserRepositoryError>()
+        
+        database.collection("User").document(user.id).setData(user.toDictionary()) { error in
+            if let error = error {
+                subject.send(completion: .failure(.dataUnavailable))
+            } else {
+                subject.send(user)
+                subject.send(completion: .finished)
+            }
+        }
+        
+        return subject.eraseToAnyPublisher()
+    }
+    
+    // MARK: 유저 정보 삭제하기
+    func deleteUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        let subject = PassthroughSubject<UserEntity, UserRepositoryError>()
+        
+        database.collection("User").document(user.id).delete { _ in
+            subject.send(user)
+            subject.send(completion: .finished)
+        }
+        
+        return subject.eraseToAnyPublisher()
+    }
     
 }
+
+class StubUserRepository: UserRepositoryInterface {
+    // 예제 데이터
+    private var userArr: [String: UserEntity] = [:]
+    
+    init() {
+        let testUser = UserEntity(
+            id: "1",
+            nickname: "ThisIsWonhyeong",
+            createdAt: Date()
+        )
+        userArr[testUser.id] = testUser
+        
+    }
+    func fetchUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        if let user = userArr[user.id] {
+            return Just(user).setFailureType(to: UserRepositoryError.self).eraseToAnyPublisher()
+        } else {
+            // 사용자 정보 존재하지 않을 경우, .notFound 에러 반환
+            return Fail(error: UserRepositoryError.notFound).eraseToAnyPublisher()
+        }
+    }
+    
+    func addUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        userArr[user.id] = user
+        return Just(user).setFailureType(to: UserRepositoryError.self).eraseToAnyPublisher()
+    }
+    
+    func updateUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        if userArr[user.id] != nil {
+            userArr[user.id] = user
+            return Just(user).setFailureType(to: UserRepositoryError.self).eraseToAnyPublisher()
+        } else {
+            return Fail(error: UserRepositoryError.notFound).eraseToAnyPublisher()
+        }
+    }
+    
+    func deleteUser(_ user: UserEntity) -> AnyPublisher<UserEntity, UserRepositoryError> {
+        if userArr.removeValue(forKey: user.id) != nil {
+            return Just(user).setFailureType(to: UserRepositoryError.self).eraseToAnyPublisher()
+        } else {
+            return Fail(error: UserRepositoryError.notFound).eraseToAnyPublisher()
+        }
+    }
+ }


### PR DESCRIPTION
사용자 정보를 읽기 위한 fetchUser 메서드 추가
새로운 사용자 정보를 추가하기 위한 addUser 메서드 추가
기존 사용자 정보를 업데이트하기 위한 updateUser 메서드 추가
사용자 정보를 삭제하기 위한 deleteUser 메서드 추가
StubUserRepository 클래스 구현

테스트용으로 사용자 정보를 관리하기 위한 StubUserRepository 클래스 추가
fetchUser, addUser, updateUser, deleteUser 메서드를 구현하여 테스트 데이터 관리