### PR TITLE
feat: Firestore를 사용하여 음악 데이터를 추가, 조회, 삭제하는 MusicRepository 클래스를 구현했습니다.

### DIFF
--- a/Here-Hear.xcodeproj/project.pbxproj
+++ b/Here-Hear.xcodeproj/project.pbxproj
@@ -35,7 +35,6 @@
 		04A747242B85DCDB00182C5F /* Color+StringConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A747232B85DCDB00182C5F /* Color+StringConverter.swift */; };
 		04A747272B8738F900182C5F /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = 04A747262B8738F900182C5F /* GoogleSignIn */; };
 		04A747292B8738F900182C5F /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 04A747282B8738F900182C5F /* GoogleSignInSwift */; };
-		04A7472D2B87410300182C5F /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 04A7472C2B87410300182C5F /* GoogleService-Info.plist */; };
 		04A7472F2B88600100182C5F /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A7472E2B88600100182C5F /* LoginView.swift */; };
 		04A747332B88647800182C5F /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A747322B88647800182C5F /* AuthViewModel.swift */; };
 		04A747372B8872D100182C5F /* ServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A747362B8872D100182C5F /* ServiceError.swift */; };
@@ -50,6 +49,7 @@
 		04A747532B8DBB3600182C5F /* FeelingEntity+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A747522B8DBB3600182C5F /* FeelingEntity+Mock.swift */; };
 		04A747552B8DBB7500182C5F /* LocationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A747542B8DBB7500182C5F /* LocationEntity.swift */; };
 		04A747582B8DBBF900182C5F /* GeohashService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A747572B8DBBF900182C5F /* GeohashService.swift */; };
+		5B0BFDE52B8DCE840010CF2B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5B0BFDE42B8DCE840010CF2B /* GoogleService-Info.plist */; };
 		5BDBBD192B846F9400DEB7DC /* Color+HexConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDBBD182B846F9400DEB7DC /* Color+HexConverter.swift */; };
 		5BDBBD1B2B846F9F00DEB7DC /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDBBD1A2B846F9F00DEB7DC /* DIContainer.swift */; };
 		5BDBBD1D2B846FA900DEB7DC /* ViewComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDBBD1C2B846FA900DEB7DC /* ViewComponent.swift */; };
@@ -109,7 +109,6 @@
 		04A7471F2B85C37E00182C5F /* Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Weather.swift; sourceTree = "<group>"; };
 		04A747212B85D72400182C5F /* CGPoint+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CGPoint+Extension.swift"; sourceTree = "<group>"; };
 		04A747232B85DCDB00182C5F /* Color+StringConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+StringConverter.swift"; sourceTree = "<group>"; };
-		04A7472C2B87410300182C5F /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../GoogleService-Info.plist"; sourceTree = "<group>"; };
 		04A7472E2B88600100182C5F /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		04A747322B88647800182C5F /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		04A747362B8872D100182C5F /* ServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceError.swift; sourceTree = "<group>"; };
@@ -124,6 +123,7 @@
 		04A747522B8DBB3600182C5F /* FeelingEntity+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeelingEntity+Mock.swift"; sourceTree = "<group>"; };
 		04A747542B8DBB7500182C5F /* LocationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationEntity.swift; sourceTree = "<group>"; };
 		04A747572B8DBBF900182C5F /* GeohashService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeohashService.swift; sourceTree = "<group>"; };
+		5B0BFDE42B8DCE840010CF2B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		5BDBBD182B846F9400DEB7DC /* Color+HexConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+HexConverter.swift"; sourceTree = "<group>"; };
 		5BDBBD1A2B846F9F00DEB7DC /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
 		5BDBBD1C2B846FA900DEB7DC /* ViewComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewComponent.swift; sourceTree = "<group>"; };
@@ -199,7 +199,7 @@
 			isa = PBXGroup;
 			children = (
 				04A7473E2B89D47A00182C5F /* Here-Hear.entitlements */,
-				04A7472C2B87410300182C5F /* GoogleService-Info.plist */,
+				5B0BFDE42B8DCE840010CF2B /* GoogleService-Info.plist */,
 				5BDBBD3C2B8484F000DEB7DC /* Info.plist */,
 				5BDBBD132B846F4C00DEB7DC /* General */,
 				04A746BF2B8464A800182C5F /* Preview Content */,
@@ -553,7 +553,7 @@
 				5BDBBD352B8483D500DEB7DC /* Localizable.xcstrings in Resources */,
 				04A746BE2B8464A800182C5F /* Assets.xcassets in Resources */,
 				5BDBBD382B84844200DEB7DC /* InfoPlist.strings in Resources */,
-				04A7472D2B87410300182C5F /* GoogleService-Info.plist in Resources */,
+				5B0BFDE52B8DCE840010CF2B /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Here-Hear/Repository/MusicRepository.swift
+++ b/Here-Hear/Repository/MusicRepository.swift
@@ -6,11 +6,108 @@
 //
 
 import Foundation
+import Combine
+
+import FirebaseFirestore
+
+enum MusicRepositoryError: Error {
+    case nilSelf
+    case emptyData
+    case custom(Error)
+}
 
 protocol MusicRepositoryInterface {
-    
+    func addMusic(_ music: MusicEntity) -> AnyPublisher<MusicEntity, MusicRepositoryError>
+    func fetchMusic(ofIds ids: [String]) -> AnyPublisher<[MusicEntity], MusicRepositoryError>
+    func deleteMusic(ofId id: String) -> AnyPublisher<Void, MusicRepositoryError>
 }
 
 class MusicRepository: MusicRepositoryInterface {
+    private let collectionRef = Firestore.firestore().collection("Music")
     
+    // MARK: - 새로운 MusicEntity 추가
+    
+    /// MusicEntity를 데이터베이스에 추가하는 메서드
+    /// - Parameter music: MusicEntity
+    /// - Returns: 추가한 MusicEntity와 MusicRepositoryError를 각각 Output과 Error로 가지는 AnyPublisher
+    func addMusic(_ music: MusicEntity) -> AnyPublisher<MusicEntity, MusicRepositoryError> {
+        Future { [weak self] promise in
+            guard let self else {
+                promise(.failure(MusicRepositoryError.nilSelf))
+                return
+            }
+            
+            do {
+                try self.collectionRef
+                    .document(music.id)
+                    .setData(from: music)
+                promise(.success(music))
+            } catch {
+                promise(.failure(MusicRepositoryError.custom(error)))
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    // MARK: - MusicEntity 가져오기
+    
+    /// 주어진 MusicEntity의 id배열로 해당하는 MusicEntity를 데이터베이스에서 가져오는 메서드
+    /// - Parameter ids: MusicEntity id 배열
+    /// - Returns: 가져온 MusicEntity배열과 MusicRepositoryError를 각각 Output과 Error로 가지는 AnyPublisher
+    func fetchMusic(ofIds ids: [String]) -> AnyPublisher<[MusicEntity], MusicRepositoryError> {
+        Future { [weak self] promise in
+            guard let self else {
+                promise(.failure(MusicRepositoryError.nilSelf))
+                return
+            }
+                     
+            self.collectionRef
+                .whereField("id", in: ids)
+                .getDocuments { snapshot, error in
+                    if let error {
+                        promise(.failure(MusicRepositoryError.custom(error)))
+                        return
+                    }
+                    
+                    guard let snapshot else {
+                        promise(.failure(MusicRepositoryError.emptyData))
+                        return
+                    }
+                    
+                    let entities: [MusicEntity] = snapshot.documents.compactMap {
+                        try? $0.data(as: MusicEntity.self)
+                    }
+                    
+                    promise(.success(entities))
+                }
+        }
+        .eraseToAnyPublisher()
+    }
+    
+    // MARK: - MusicEntity 삭제
+    
+    /// 데이터베이스에서 id에 해당하는 MusicEntity를 삭제하는 메서드
+    /// - Parameter id: 삭제할 MusicEntity의 id
+    /// - Returns: AnyPublisher<Void, MusicRepositoryError>
+    func deleteMusic(ofId id: String) -> AnyPublisher<Void, MusicRepositoryError> {
+        Future { [weak self] promise in
+            guard let self else {
+                promise(.failure(MusicRepositoryError.nilSelf))
+                return
+            }
+            
+            self.collectionRef
+                .document(id)
+                .delete { error in
+                    if let error {
+                        promise(.failure(MusicRepositoryError.custom(error)))
+                        return
+                    }
+                    
+                    promise(.success(()))
+                }
+            
+        }
+        .eraseToAnyPublisher()
+    }
 }


### PR DESCRIPTION


- addMusic 메서드: MusicEntity를 Firestore에 추가하는 기능을 구현했습니다.
- fetchMusic 메서드: 주어진 id 배열로부터 해당하는 MusicEntity를 Firestore에서 가져오는 기능을 추가했습니다.
- deleteMusic 메서드: 주어진 id에 해당하는 MusicEntity를 Firestore에서 삭제하는 기능을 구현했습니다.

각 메서드는 Combine을 사용하여 AnyPublisher를 반환하며, 에러 핸들링을 위해 MusicRepositoryError 열거형을 활용했습니다.